### PR TITLE
Update the actor registry to index by ID

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -18,6 +18,7 @@ local utf8 = require 'utf8'
 local scenes = {}
 
 L = {}
+local L = L
 
 L.actors = {}
 L.scene = nil
@@ -55,16 +56,11 @@ function L.screen.setResolution(w, h)
 end
 
 function L.registerActor(act)
-    table.insert(L.actors, act)
+    L.actors[act.__id] = act
 end
 
 function L.getActorById(id)
-    for i, v in ipairs(L.actors) do
-        if v.__id == id then
-            return v, i
-        end
-    end
-    return nil
+    return L.actors[id]
 end
 
 function L.destroyActor(id)
@@ -78,7 +74,7 @@ function L.destroyActor(id)
         act:__destroy()
     end
 
-    table.remove(L.actors, ind)
+   L.actors[id] = nil
 end
 
 function L.printf(fmt, ...)

--- a/main.lua
+++ b/main.lua
@@ -64,7 +64,7 @@ function L.getActorById(id)
 end
 
 function L.destroyActor(id)
-    local act, ind = L.getActorById(id)
+    local act = L.getActorById(id)
 
     if act == nil then
         error(string.format('Actor %s is not in actor list. This actor may not exist! Are you trying to destroy the scene?', id))


### PR DESCRIPTION
Rin says they forgot to update this code when actor IDs were implemented.
With the implementation of UUIDs, there is even less reason to continue storing actors positionally.